### PR TITLE
getStateByThunk returns `[state, do, theID]`.

### DIFF
--- a/src/states.ts
+++ b/src/states.ts
@@ -39,9 +39,9 @@ export const getStateOrDefault = <S extends State>(classState: ClassState<S>, my
 export const getStateByThunk = <S extends State, R extends ThunkModuleFunc<S>>(
   theUse: UseThunk<S, R>,
   myID?: string,
-): [S, string, DispatchFuncMap<S, R>] => {
+): [S, DispatchFuncMap<S, R>, string] => {
   const [classState, theDo] = theUse
   const theID = myID ? myID : getDefaultID(classState)
   const state = getStateOrDefault(classState, theID)
-  return [state, theID, theDo]
+  return [state, theDo, theID]
 }

--- a/tests/TheParent.tsx
+++ b/tests/TheParent.tsx
@@ -42,9 +42,13 @@ export default (props: Props) => {
 
   const defaultParent2 = getStateOrDefault(classStateParent)
 
-  const [defaultParent3, defaultID3, doParent3] = getStateByThunk(useParent)
+  const [defaultParent3, doParent3, defaultID3] = getStateByThunk(useParent)
 
-  const [parent4, parentID4, doParent4] = getStateByThunk(useParent, myID)
+  const [parent4, doParent4, parentID4] = getStateByThunk(useParent, myID)
+
+  const [parent5, doParent5] = getStateByThunk(useParent, myID)
+
+  const [parent6] = getStateByThunk(useParent, myID)
 
   const onClick = () => {
     doParent.increment(myID)
@@ -83,7 +87,8 @@ export default (props: Props) => {
         {`${defaultParent === defaultParent3} ${defaultID === defaultID3} ${doParent === doParent3}`}
       </div>
       <div className='parent-get-state-by-thunk-2'>
-        {myID}: {`${parent === parent4} ${myID === parentID4} ${doParent === doParent4}`}
+        {myID}:{' '}
+        {`${parent === parent4} ${myID === parentID4} ${doParent === doParent4} ${parent5 === parent4} ${doParent5 === doParent4} ${parent6 === parent4}`}
       </div>
       <button className='parent-button' type='button' onClick={onClick}>
         {myID}: click me

--- a/tests/many-apps.test.tsx
+++ b/tests/many-apps.test.tsx
@@ -148,10 +148,10 @@ it('many-parents (init and remove)', () => {
   expect(parentGetStateByThunks[2].textContent).toBe(`${parentID2}: true true true`)
   expect(parentGetStateByThunks[3].textContent).toBe(`${parentID3}: true true true`)
 
-  expect(parentGetStateByThunk2s[0].textContent).toBe(`${parentID0}: true true true`)
-  expect(parentGetStateByThunk2s[1].textContent).toBe(`${parentID1}: true true true`)
-  expect(parentGetStateByThunk2s[2].textContent).toBe(`${parentID2}: true true true`)
-  expect(parentGetStateByThunk2s[3].textContent).toBe(`${parentID3}: true true true`)
+  expect(parentGetStateByThunk2s[0].textContent).toBe(`${parentID0}: true true true true true true`)
+  expect(parentGetStateByThunk2s[1].textContent).toBe(`${parentID1}: true true true true true true`)
+  expect(parentGetStateByThunk2s[2].textContent).toBe(`${parentID2}: true true true true true true`)
+  expect(parentGetStateByThunk2s[3].textContent).toBe(`${parentID3}: true true true true true true`)
 
   expect(parentDefaultIDs[0].textContent).toBe(`${parentID0}: ${parentID0}`)
   expect(parentDefaultIDs[1].textContent).toBe(`${parentID1}: ${parentID0}`)

--- a/types/states.d.ts
+++ b/types/states.d.ts
@@ -6,4 +6,4 @@ export declare const getDefaultID: <S extends State>(classState: ClassState<S>) 
 export declare const getNode: <S extends State>(classState: ClassState<S>, myID?: string) => NodeState<S> | null;
 export declare const getState: <S extends State>(classState: ClassState<S>, myID?: string) => S | null;
 export declare const getStateOrDefault: <S extends State>(classState: ClassState<S>, myID?: string) => S;
-export declare const getStateByThunk: <S extends State, R extends ThunkModuleFunc<S>>(theUse: UseThunk<S, R>, myID?: string) => [S, string, DispatchFuncMap<S, R>];
+export declare const getStateByThunk: <S extends State, R extends ThunkModuleFunc<S>>(theUse: UseThunk<S, R>, myID?: string) => [S, DispatchFuncMap<S, R>, string];


### PR DESCRIPTION
The purpose is to be consistent with useThunk (`[classState, do]`).