### PR TITLE
moduleState instead of refModuleState in ThunkContext.

### DIFF
--- a/src/defaultThunkFuncs/init/index.ts
+++ b/src/defaultThunkFuncs/init/index.ts
@@ -6,6 +6,8 @@ import initCore, { INIT, reduceInit } from './initCore'
 export { INIT, reduceInit }
 
 // InitParams
+// Sometimes we don't want to specify myID.
+// Therefore, we use {} to have myID be optional.
 export interface InitParams<S extends State> {
   myID?: string
   state: S

--- a/src/defaultThunkFuncs/remove.ts
+++ b/src/defaultThunkFuncs/remove.ts
@@ -26,10 +26,10 @@ export const reduceRemove = <S extends State>(
     }, {})
 
   // defaultID
-  const newState = Object.assign({}, moduleState, { nodes: newNodes })
-  if (newState.defaultID === myID) {
-    newState.defaultID = null
+  const newModuleState = Object.assign({}, moduleState, { nodes: newNodes })
+  if (newModuleState.defaultID === myID) {
+    newModuleState.defaultID = null
   }
 
-  return newState
+  return newModuleState
 }

--- a/src/defaultThunkFuncs/setDefaultID.ts
+++ b/src/defaultThunkFuncs/setDefaultID.ts
@@ -14,5 +14,6 @@ export const reduceSetDefaultID = <S extends State>(
   const { myID } = action
 
   const toUpdate: Partial<ModuleState<S>> = { defaultID: myID }
+
   return Object.assign({}, moduleState, toUpdate)
 }

--- a/src/defaultThunkFuncs/upsert.ts
+++ b/src/defaultThunkFuncs/upsert.ts
@@ -1,9 +1,23 @@
 import type { BaseAction } from '../action'
 import type { ModuleState, NodeState, State } from '../states'
+import type { Thunk } from '../thunk'
 import { deepCopy } from '../utils'
+import { setDefaultID } from './setDefaultID'
 
 export const UPSERT = '@chhsiao1981/use-thunk/UPSERT'
-export const upsert = <S extends State>(myID: string, data: Partial<S>): BaseAction => ({
+export const upsert = <S extends State>(myID: string, data: Partial<S>): Thunk<S> => {
+  return (set, _get, _getOrNull, _dispatch, getModuleState) => {
+    set(upsertCore(myID, data))
+
+    const { defaultID } = getModuleState()
+
+    if (!defaultID) {
+      set(setDefaultID(myID))
+    }
+  }
+}
+
+const upsertCore = <S extends State>(myID: string, data: Partial<S>): BaseAction => ({
   myID,
   type: UPSERT,
   data,

--- a/src/registerThunk.ts
+++ b/src/registerThunk.ts
@@ -5,23 +5,23 @@
 //   system and return void.
 import { createContext, type Dispatch, type SetStateAction } from 'react'
 import type { ModuleState, State } from './states'
+import type { Context } from './thunkContext'
 import { THUNK_CONTEXT_MAP } from './thunkContext'
 import type { ThunkModule } from './thunkModule'
 
-export default <S extends State>(theDo: ThunkModule<S>) => {
-  const { name, defaultState } = theDo
+export default <S extends State>(module: ThunkModule<S>) => {
+  const { name, defaultState } = module
 
   if (THUNK_CONTEXT_MAP.theMap[name]) {
     console.warn('registerThunk: already init:', name)
     return
   }
 
-  const moduleState: ModuleState<S> = { name, nodes: {}, defaultState }
+  const initModuleState: ModuleState<S> = { name: module.name, nodes: {}, defaultState }
   const setModuleState: Dispatch<SetStateAction<ModuleState<S>>> = () => {}
-  const refModuleState = { current: moduleState }
-  const context = createContext({ refModuleState: refModuleState, setModuleState })
+  const context = createContext<Context<S>>({ moduleState: initModuleState, setModuleState })
 
-  THUNK_CONTEXT_MAP.theMap[name] = { context, refModuleState }
+  THUNK_CONTEXT_MAP.theMap[name] = { context, initModuleState }
   const theList = Object.keys(THUNK_CONTEXT_MAP.theMap).sort()
   THUNK_CONTEXT_MAP.theList = theList
 

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -6,7 +6,17 @@ import type { ModuleState, NodeState, NodeStateMap, State } from './types'
 export type { ModuleState, NodeState, NodeStateMap, State }
 
 export const getDefaultID = <S extends State>(moduleState: ModuleState<S>, isMust = false): string => {
-  return moduleState.defaultID ?? (isMust ? genID() : '')
+  if (moduleState.defaultID) {
+    return moduleState.defaultID
+  }
+  if (!isMust) {
+    return ''
+  }
+
+  // XXX magic for defaultID
+  const defaultID = genID()
+  moduleState.defaultID = defaultID
+  return defaultID
 }
 
 export const getNodeOrNull = <S extends State>(
@@ -56,6 +66,8 @@ export const getStateByModule = <S extends State>(
   moduleState.nodes[theID] = newNode
 
   // 2. check defaultID
+  //    we still need this because myID can be specified
+  //    and not calling getDefaultID.
   if (!moduleState.defaultID) {
     moduleState.defaultID = theID
   }

--- a/src/thunkContext/ThunkContext.tsx
+++ b/src/thunkContext/ThunkContext.tsx
@@ -18,19 +18,18 @@ const ThunkContext = (props: Props): JSX.Element => {
   const theModule = modules[0]
 
   // 1. get the context and moduleState from context map.
-  const { context: Context_m, refModuleState } = THUNK_CONTEXT_MAP.theMap[theModule]
+  const { context: Context_m, initModuleState } = THUNK_CONTEXT_MAP.theMap[theModule]
 
   // 2. setup moduleState.
   // biome-ignore lint/correctness/useHookAtTopLevel: the order is fixed.
-  const [moduleState, setModuleState] = useState(refModuleState.current)
-  refModuleState.current = moduleState
+  const [moduleState, setModuleState] = useState(initModuleState)
 
   // 3. value reset only if moduleState is changed.
   // biome-ignore lint/correctness/useHookAtTopLevel: the order is fixed.
   const value = useMemo(
     () => ({
-      refModuleState: refModuleState,
-      setModuleState: setModuleState,
+      moduleState,
+      setModuleState,
     }),
     [moduleState],
   )

--- a/src/thunkContext/thunkContextMap.ts
+++ b/src/thunkContext/thunkContextMap.ts
@@ -5,12 +5,10 @@ import type { Context } from './types'
 export type ThunkContextMap = {
   theMap: {
     [moduleName: string]: {
-      // biome-ignore lint/suspicious/noExplicitAny: ThunkContextMap can be any type
+      // biome-ignore lint/suspicious/noExplicitAny: module can be any type
       context: rContext<Context<any>>
-
-      // we need to use refModuleState to sync all the moduleState in all ops.
-      // biome-ignore lint/suspicious/noExplicitAny: ThunkContextMap can be any type
-      refModuleState: { current: ModuleState<any> }
+      // biome-ignore lint/suspicious/noExplicitAny: module can be any type
+      initModuleState: ModuleState<any>
     }
   }
   theList: string[]

--- a/src/thunkContext/types.ts
+++ b/src/thunkContext/types.ts
@@ -2,7 +2,6 @@ import type { Dispatch, SetStateAction } from 'react'
 import type { ModuleState, State } from '../states'
 
 export type Context<S extends State> = {
-  // INFO: we use refModuleState to reference across all the useThunk of the same module in different ops.
-  refModuleState: { current: ModuleState<S> }
+  moduleState: ModuleState<S>
   setModuleState: Dispatch<SetStateAction<ModuleState<S>>>
 }

--- a/src/thunkModule/doModule.ts
+++ b/src/thunkModule/doModule.ts
@@ -25,28 +25,21 @@ export const DO_MODULE_MAP: doModuleMap<any, any> = {}
 // biome-ignore lint/suspicious/noExplicitAny: ok for type utility functions.
 export type toDoModule<T extends ThunkModule<any>> = doModule<any, T>
 
-export const constructDoModule = <S extends State, T extends ThunkModule<S>>(
-  module: T,
-  set: set<S>,
-  doModule: doModule<S, T>,
-) => {
-  Object.keys(module)
-    // default and name are reserved words.
-    // functions starting reduce are included in default and not exported.
+export const constructDoModule = <S extends State, T extends ThunkModule<S>>(module: T, set: set<S>) => {
+  const doModule = Object.keys(module)
     .filter((each) => typeof module[each] === 'function')
-    .reduce((val, eachAction) => {
-      if (val[eachAction]) {
+    .reduce(
+      (val, eachAction) => {
+        // because action is a function.
+        const action = module[eachAction] as ActionFunc<S>
+
+        // @ts-expect-error we would like to reduce to doModule
+        // biome-ignore lint/suspicious/noExplicitAny: action parameters can be any types.
+        val[eachAction] = (...params: any[]) => set(action(...params))
         return val
-      }
-
-      // because action is a function.
-      const action = module[eachAction] as ActionFunc<S>
-
-      // @ts-expect-error we would like to reduce to doModule
-      // biome-ignore lint/suspicious/noExplicitAny: action parameters can be any types.
-      val[eachAction] = (...params: any[]) => set(action(...params))
-      return val
-    }, doModule)
+      },
+      {} as doModule<S, T>,
+    )
 
   Object.keys(DEFAULT_THUNK_FUNC_MAP).reduce((val, eachAction) => {
     if (val[eachAction]) {
@@ -62,9 +55,11 @@ export const constructDoModule = <S extends State, T extends ThunkModule<S>>(
     return val
   }, doModule)
 
+  DO_MODULE_MAP[module.name] = doModule
+
   return doModule
 }
 
-export const doMod = <S extends State, T extends ThunkModule<S>>(name: string) => {
-  return DO_MODULE_MAP[name] as toDoModule<T>
+export const doMod = <S extends State, T extends ThunkModule<S>>(moduleName: string) => {
+  return DO_MODULE_MAP[moduleName] as toDoModule<T>
 }

--- a/src/useThunk/index.ts
+++ b/src/useThunk/index.ts
@@ -15,33 +15,19 @@ export type UseThunk<S extends State, T extends ThunkModule<S>> = [
 export default <S extends State, T extends ThunkModule<S>>(module: T) => {
   const { name } = module
 
-  // 1. It requires shared nodes for the same module to have the same setMap.
-  const isFirstTime = !DO_MODULE_MAP[name]
-  if (isFirstTime) {
-    DO_MODULE_MAP[name] = {}
-  }
-  const doModule = DO_MODULE_MAP[name] as toDoModule<T>
-
-  // 2. reducer.
-  //    theReducer is different for different useThunk,
-  //    even within the same module.
-  //    However, because theReducer is a pure function by
-  //    having ModuleState as the input. It is ok to have
-  //    different reducers within the same module.
   const theReducer = useMemo(() => createReducer<S>(), [])
 
-  // 3. useThunkReducer
+  // 2. useThunkReducer
   const [moduleState, set] = useThunkReducer(theReducer, name)
+
+  if (!DO_MODULE_MAP[name]) {
+    constructDoModule(module, set)
+  }
+  const doModule = DO_MODULE_MAP[name] as toDoModule<T>
 
   const ret: UseThunk<S, T> = useMemo(() => {
     return [moduleState, doModule]
   }, [moduleState, doModule])
-
-  if (!isFirstTime) {
-    return ret
-  }
-
-  constructDoModule(module, set, doModule)
 
   return ret
 }

--- a/src/useThunk/useThunkReducer.ts
+++ b/src/useThunk/useThunkReducer.ts
@@ -1,9 +1,9 @@
 //https://medium.com/solute-labs/configuring-thunk-action-creators-and-redux-dev-tools-with-reacts-usereducer-hook-5a1608476812
 //https://github.com/nathanbuchar/react-hook-thunk-reducer/blob/master/src/thunk-reducer.js
 
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import type { BaseAction } from '../action'
-import { upsert } from '../defaultThunkFuncs/upsert'
+import { upsert } from '../defaultThunkFuncs'
 import type { Reducer } from '../reducer'
 import { getStateByModule, getStateOrNullByModule, type ModuleState, type State } from '../states'
 import type { dispatch, get, getModuleState, getOrNull, set } from '../thunk'
@@ -18,23 +18,25 @@ import { THUNK_CONTEXT_MAP } from '../thunkContext'
 export default <S extends State>(reducer: Reducer<S>, moduleName: string): [ModuleState<S>, set<S>] => {
   const { context } = THUNK_CONTEXT_MAP.theMap[moduleName]
 
-  const { refModuleState, setModuleState: setModuleState_c } = useContext(context)
-  const getModuleState: getModuleState<S> = useCallback(() => {
-    return refModuleState.current
-  }, [refModuleState]) as () => ModuleState<S>
+  // moduleState_c as the snapshot of the moduleState from the context.
+  const { moduleState: moduleState_c, setModuleState: setModuleState_c } = useContext(context)
 
-  const setModuleState = useCallback(
-    (newModuleState: ModuleState<S>) => {
-      refModuleState.current = newModuleState
-      setModuleState_c(newModuleState)
-    },
-    [refModuleState, setModuleState_c],
-  )
+  // refModuleState is used only internally to sync the moduleState after dispatch.
+  const moduleState = useMemo(() => ({ current: moduleState_c }), [moduleState_c])
+
+  // always use getModuleState to get the current moduleState.
+  const getModuleState: getModuleState<S> = useCallback(() => {
+    return moduleState.current
+  }, [moduleState])
+
+  const setModuleState = (newModuleState: ModuleState<S>) => {
+    moduleState.current = newModuleState
+    setModuleState_c(newModuleState)
+  }
 
   const getOrNull: getOrNull<S> = useCallback(
     (id?: string) => {
-      const moduleState = getModuleState()
-      const state = getStateOrNullByModule(moduleState, id)
+      const state = getStateOrNullByModule(getModuleState(), id)
       return state
     },
     [getModuleState],
@@ -42,8 +44,7 @@ export default <S extends State>(reducer: Reducer<S>, moduleName: string): [Modu
 
   const get: get<S> = useCallback(
     (id?: string) => {
-      const moduleState = getModuleState()
-      const state = getStateByModule(moduleState, id)
+      const state = getStateByModule(getModuleState(), id)
       return state
     },
     [getModuleState],
@@ -51,11 +52,10 @@ export default <S extends State>(reducer: Reducer<S>, moduleName: string): [Modu
 
   const reduce = useCallback(
     (action: BaseAction): ModuleState<S> => {
-      const moduleState = getModuleState()
-      const newModuleState = reducer(moduleState, action)
+      const newModuleState = reducer(getModuleState(), action)
       return newModuleState
     },
-    [reducer, getModuleState],
+    [getModuleState, reducer],
   )
 
   const dispatch: dispatch<S> = useCallback(
@@ -68,9 +68,10 @@ export default <S extends State>(reducer: Reducer<S>, moduleName: string): [Modu
 
       // action is not function. so action is BaseAction
       const newModuleState = reduce(action)
+
       setModuleState(newModuleState)
     },
-    [getModuleState, setModuleState, reduce],
+    [getModuleState, setModuleState_c, reduce],
   )
 
   const set: set<S> = useCallback(
@@ -83,16 +84,15 @@ export default <S extends State>(reducer: Reducer<S>, moduleName: string): [Modu
 
         // we have the data, we can do upsert.
         const action = upsert(actionOrID, data)
-        const newModuleState = reduce(action)
-        setModuleState(newModuleState)
+        dispatch(action)
         return
       }
 
       // actionOrID is action
       dispatch(actionOrID)
     },
-    [getModuleState, setModuleState, reduce],
+    [dispatch, upsert],
   )
 
-  return [refModuleState.current, set]
+  return [moduleState_c, set] // moduleState_c as the snapshot from the context.
 }

--- a/tests/Child.tsx
+++ b/tests/Child.tsx
@@ -1,5 +1,5 @@
 import { getDefaultID, getStateOrNullByModule, useThunk } from '../src'
-import * as DoChild from './child'
+import * as ModChild from './child'
 
 export type Props = {
   myID: string
@@ -8,7 +8,7 @@ export type Props = {
 export default (props: Props) => {
   const { myID } = props
 
-  const useChild = useThunk<DoChild.State, typeof DoChild>(DoChild)
+  const useChild = useThunk<ModChild.State, typeof ModChild>(ModChild)
   const [moduleChild, doChild] = useChild
   const child = getStateOrNullByModule(moduleChild, myID) || moduleChild.defaultState
 

--- a/tests/Parent.tsx
+++ b/tests/Parent.tsx
@@ -7,7 +7,7 @@ import {
   useThunk,
 } from '../src'
 import Child from './Child'
-import * as DoParent from './parent'
+import * as ModParent from './parent'
 
 export type Props = {
   myID: string
@@ -20,8 +20,8 @@ export default (props: Props) => {
 
   console.info('Parent (start): myID:', myID, 'childID0:', childID0, 'childID1:', childID1)
 
-  const useParent = useThunk<DoParent.State, typeof DoParent>(DoParent)
-  const [moduleParent, _doParent] = useParent
+  const useParent = useThunk<ModParent.State, typeof ModParent>(ModParent)
+  const [moduleParent] = useParent
   const [parent, doParent] = getState(useParent, myID)
 
   const { count } = parent
@@ -32,7 +32,7 @@ export default (props: Props) => {
 
   const defaultNode = getNodeOrNull(moduleParent)
 
-  const defaultParent = getStateOrNullByModule(moduleParent) || DoParent.defaultState
+  const defaultParent = getStateOrNullByModule(moduleParent) || ModParent.defaultState
 
   const defaultParent2 = getStateByModule(moduleParent)
 

--- a/tests/child.ts
+++ b/tests/child.ts
@@ -12,6 +12,7 @@ export const defaultState: State = Object.freeze({
 
 export const init = (myID?: string): Thunk<State> => {
   return (set) => {
+    console.info('child: to init: myID:', myID)
     set(_init({ myID, state: defaultState }))
   }
 }
@@ -22,6 +23,17 @@ export const increment = (myID: string, num = 1): Thunk<State> => {
     const { count } = me
 
     set(myID, { count: count + num })
+    const me2 = get(myID)
+    if (me2 === me) {
+      console.error('increment: me2 === me (copy-on-write)')
+    }
+
+    // set with no-data.
+    set(myID)
+    const me3 = get(myID)
+    if (me2 !== me3) {
+      console.error('increment: me2 !== me3')
+    }
   }
 }
 

--- a/tests/many-apps.test.tsx
+++ b/tests/many-apps.test.tsx
@@ -1,24 +1,25 @@
 import { act, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
-import { afterEach, beforeEach, expect, it } from 'vitest'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { genID, registerThunk, ThunkContext, useThunk } from '../src/index'
-import * as DoChild from './child'
+import * as ModChild from './child'
 import Parent from './Parent'
-import * as DoParent from './parent'
+import * as ModParent from './parent'
 
 let container: HTMLDivElement | null
 let root: ReactDOM.Root | null
+
 beforeEach(() => {
-  registerThunk(DoParent)
-  registerThunk(DoParent)
-  registerThunk(DoChild)
+  registerThunk(ModParent)
+  registerThunk(ModParent)
+  registerThunk(ModChild)
 
   container = document.createElement('div')
   document.body.appendChild(container)
 
   root = ReactDOM.createRoot(container)
 
-  // @ts-expect-error
+  // @ts-expect-error set IS_REACT_ACT_ENVIRONMENT
   global.IS_REACT_ACT_ENVIRONMENT = true
 })
 
@@ -32,27 +33,29 @@ afterEach(() => {
   container = null
 })
 
-it('many-parents (init and remove)', () => {
-  // biome-ignore lint/complexity/noBannedTypes: Props is a required type.
-  type Props = {}
-  const App = (_props: Props) => {
-    const [_7, doParent] = useThunk<DoParent.State, typeof DoParent>(DoParent)
-    const [_8, doChild] = useThunk<DoChild.State, typeof DoChild>(DoChild)
-    const [parentID0, _1] = useState(() => genID())
-    const [parentID1, _2] = useState(() => genID())
-    const [childID0, _3] = useState(() => genID())
-    const [childID1, _4] = useState(() => genID())
-    const [childID2, _5] = useState(() => genID())
-    const [childID3, _6] = useState(() => genID())
+it('many-parents (init and remove)', async () => {
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  // 2. Intercept the environment error bubble up
+  const App = () => {
+    const [_7, doParent] = useThunk<ModParent.State, typeof ModParent>(ModParent)
+    const [_8, doChild] = useThunk<ModChild.State, typeof ModChild>(ModChild)
+    const [parentID0] = useState(() => genID())
+    const [parentID1] = useState(() => genID())
+    const [childID0] = useState(() => genID())
+    const [childID1] = useState(() => genID())
+    const [childID2] = useState(() => genID())
+    const [childID3] = useState(() => genID())
 
     // init
     useEffect(() => {
       console.log('many-parents (init): parentID:', parentID0)
-      doChild.init(childID0)
+      doChild.upsert(childID0, {})
       doChild.init(childID1)
       doChild.init(childID2)
       doChild.init(childID3)
       doChild.init()
+      doChild.update('non-exist', {})
     }, [doParent, doChild])
 
     return (
@@ -73,9 +76,11 @@ it('many-parents (init and remove)', () => {
   }
 
   // do act
+
   act(() => {
     root?.render(<App2 />)
   })
+
   if (container === null) {
     return
   }
@@ -194,6 +199,7 @@ it('many-parents (init and remove)', () => {
   console.info('many-apps: to click parent-0 button (1st)')
 
   act(() => parentButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
+  expect(consoleSpy).not.toHaveBeenCalled()
 
   expect(parentCounts[0].textContent).toBe(`${parentID0}: 1`)
   expect(parentCounts[1].textContent).toBe(`${parentID1}: 0`)
@@ -214,6 +220,8 @@ it('many-parents (init and remove)', () => {
 
   console.info('many-apps: to click child-0 button (1st)')
   act(() => childButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
+  expect(consoleSpy).not.toHaveBeenCalled()
+
   console.info('many-apps: to click child-0 button (2nd)')
   act(() => childButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
@@ -236,8 +244,10 @@ it('many-parents (init and remove)', () => {
 
   console.info('many-apps: to click child-3 button (1st)')
   act(() => childButtons[3].dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
   console.info('many-apps: to click child-3 button (2nd)')
   act(() => childButtons[3].dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
   console.info('many-apps: to click child-3 button (3rd)')
   act(() => childButtons[3].dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
@@ -363,4 +373,6 @@ it('many-parents (init and remove)', () => {
   expect(parentDefaultNodeIDs[1].textContent).toBe(`${parentID1}: 2`)
   expect(parentDefaultNodeIDs[2].textContent).toBe(`${parentID2}: 2`)
   expect(parentDefaultNodeIDs[3].textContent).toBe(`${parentID3}: 2`)
+
+  expect(consoleSpy).not.toHaveBeenCalled()
 })

--- a/tests/thunkModule/construct-do-module.test.ts
+++ b/tests/thunkModule/construct-do-module.test.ts
@@ -1,14 +1,14 @@
 import { expect, it } from 'vitest'
-import { constructDoModule, type toDoModule } from '../../src/thunkModule'
-import * as DoChild from '../child'
+import { constructDoModule } from '../../src/thunkModule'
+import * as ModChild from '../child'
 
 it('construct do module', () => {
-  // @ts-expect-error init doChild
-  const doChild: toDoModule<typeof DoChild> = {}
   const set = () => {}
-  constructDoModule(DoChild, set, doChild)
+  const doChild = constructDoModule<ModChild.State, typeof ModChild>(ModChild, set)
   expect(Object.keys(doChild).length).toBe(8)
 
-  constructDoModule(DoChild, set, doChild)
-  expect(Object.keys(doChild).length).toBe(8)
+  const doChild2 = constructDoModule<ModChild.State, typeof ModChild>(ModChild, set)
+  expect(Object.keys(doChild2).length).toBe(8)
+
+  expect(doChild).not.toBe(doChild2)
 })

--- a/tests/thunkModule/do-mod.test.ts
+++ b/tests/thunkModule/do-mod.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest'
+import { constructDoModule, doMod } from '../../src/thunkModule'
+import * as ModChild from '../child'
+
+it('construct do module', () => {
+  const set = () => {}
+  const doChild = constructDoModule<ModChild.State, typeof ModChild>(ModChild, set)
+  const doChild2 = doMod<ModChild.State, typeof ModChild>(ModChild.name)
+  expect(doChild).toBe(doChild2)
+})


### PR DESCRIPTION
1. thunkContext: moduleState instead of refModuleState in thunkContext.Context.
2. upsert as Thunk function to setDefaultID (same as init).
3. refModuleState in useThunkReducer to track the updated moduleState in dispatch.
4. copy-on-write for components, with getting newest version of moduleState for thunk functions.