### PR TITLE
moduleState as always the same across processing time.

### DIFF
--- a/src/defaultThunkFuncs/init/index.ts
+++ b/src/defaultThunkFuncs/init/index.ts
@@ -7,8 +7,6 @@ import initCore, { INIT, reduceInit } from './initCore'
 export { INIT, reduceInit }
 
 /**
- * init
- *
  * init the state. set defaultID if defaultID does not exist.
  *
  * Most of time we don't need to init because get(id) and useThunk

--- a/src/defaultThunkFuncs/init/initCore.ts
+++ b/src/defaultThunkFuncs/init/initCore.ts
@@ -1,5 +1,5 @@
 import type { BaseAction } from '../../action'
-import type { ModuleState, NodeState, NodeStateMap, State } from '../../states'
+import type { ModuleState, NodeState, State } from '../../states'
 
 export interface InitAction<S extends State> extends BaseAction {
   state: S
@@ -22,8 +22,9 @@ export const reduceInit = <S extends State>(
     id,
     state,
   }
-  const newNodes: NodeStateMap<S> = Object.assign({}, moduleState.nodes, { [id]: node })
-  const newModuleState: ModuleState<S> = Object.assign({}, moduleState, { nodes: newNodes })
 
-  return newModuleState
+  // update moduleState
+  moduleState.nodes[id] = node
+
+  return moduleState
 }

--- a/src/defaultThunkFuncs/remove.ts
+++ b/src/defaultThunkFuncs/remove.ts
@@ -1,12 +1,10 @@
 import type { BaseAction } from '../action'
-import { getDefaultID, type ModuleState, type NodeStateMap, type State } from '../states'
+import { getDefaultID, type ModuleState, type State } from '../states'
 import type { Thunk } from '../thunk'
 
 export const REMOVE = '@chhsiao1981/use-thunk/REMOVE'
 
 /**
- * remove
- *
  * remove the state.
  *
  * @param id id. use defaultID if this is not specified.
@@ -39,18 +37,11 @@ export const reduceRemove = <S extends State>(
     return moduleState
   }
 
-  const newNodes = Object.keys(moduleState.nodes)
-    .filter((each) => each !== id)
-    .reduce((r: NodeStateMap<S>, x) => {
-      r[x] = moduleState.nodes[x]
-      return r
-    }, {})
-
-  // defaultID
-  const newModuleState = Object.assign({}, moduleState, { nodes: newNodes })
-  if (newModuleState.defaultID === id) {
-    newModuleState.defaultID = null
+  // update moduleState
+  delete moduleState.nodes[id]
+  if (moduleState.defaultID === id) {
+    moduleState.defaultID = null
   }
 
-  return newModuleState
+  return moduleState
 }

--- a/src/defaultThunkFuncs/setDefaultID.ts
+++ b/src/defaultThunkFuncs/setDefaultID.ts
@@ -19,7 +19,8 @@ export const reduceSetDefaultID = <S extends State>(
 ): ModuleState<S> => {
   const { id } = action
 
-  const toUpdate: Partial<ModuleState<S>> = { defaultID: id }
+  // update moduleState
+  moduleState.defaultID = id
 
-  return Object.assign({}, moduleState, toUpdate)
+  return moduleState
 }

--- a/src/defaultThunkFuncs/update.ts
+++ b/src/defaultThunkFuncs/update.ts
@@ -6,8 +6,6 @@ import { parseArg } from './utils'
 export const UPDATE = '@chhsiao1981/use-thunk/UPDATE'
 
 /**
- * update
- *
  * update the data. no update if id or data is invalid.
  *
  * @param idOrData id or data. use defaultID if this is data.
@@ -51,8 +49,9 @@ export const reduceUpdate = <S extends State>(
 
   const newState: S = Object.assign({}, node.state, data)
   const newNode = Object.assign({}, node, { state: newState })
-  const newNodes = Object.assign({}, moduleState.nodes, { [id]: newNode })
-  const newModuleState = Object.assign({}, moduleState, { nodes: newNodes })
 
-  return newModuleState
+  // update moduleState
+  moduleState.nodes[id] = newNode
+
+  return moduleState
 }

--- a/src/defaultThunkFuncs/upsert.ts
+++ b/src/defaultThunkFuncs/upsert.ts
@@ -7,10 +7,6 @@ import { parseArg } from './utils'
 export const UPSERT = '@chhsiao1981/use-thunk/UPSERT'
 
 /**
- * upsert
- *
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
  * update the data. create the state in moduleState first if state is not in moduleState.
  *
  * @param idOrData: id or data. use defaultID if this is data.
@@ -54,8 +50,9 @@ export const reduceUpsert = <S extends State>(
 
   const newState: S = Object.assign({}, theNode.state, data)
   const newNode = Object.assign({}, theNode, { state: newState })
-  const newNodes = Object.assign({}, moduleState.nodes, { [id]: newNode })
-  const newModuleState = Object.assign({}, moduleState, { nodes: newNodes })
 
-  return newModuleState
+  // update moduleState
+  moduleState.nodes[id] = newNode
+
+  return moduleState
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   type State,
 } from './states'
 import type { dispatch, get, getModuleState, getOrNull, set, Thunk, ThunkFunc } from './thunk'
-import { ThunkContext } from './thunkContext'
+import { getMod, ThunkContext } from './thunkContext'
 import { doMod, type doModule, type ThunkModule } from './thunkModule'
 import { type UseThunk, type UseThunkModuleState, useThunk, useThunkModuleState } from './useThunk'
 import { genID } from './utils'
@@ -40,6 +40,12 @@ export {
   type doModule,
 }
 
+export {
+  // moduleState related
+  getMod,
+  type ModuleState,
+}
+
 export type {
   // thunk function
   ThunkFunc,
@@ -61,7 +67,6 @@ export type {
   getOrNull,
   dispatch,
   getModuleState,
-  ModuleState,
 }
 
 export {

--- a/src/registerThunk.ts
+++ b/src/registerThunk.ts
@@ -3,7 +3,7 @@
 //   as the proof of successful creation.
 //   However, we register Thunks to the global state management
 //   system and return void.
-import { createContext, type Dispatch, type SetStateAction } from 'react'
+import { createContext, type Dispatch, type RefObject, type SetStateAction } from 'react'
 import type { ModuleState, State } from './states'
 import type { Context } from './thunkContext'
 import { THUNK_CONTEXT_MAP } from './thunkContext'
@@ -23,11 +23,15 @@ const registerThunk = <S extends State>(module: ThunkModule<S>) => {
     return
   }
 
-  const initModuleState: ModuleState<S> = { name: module.name, nodes: {}, defaultState }
-  const setModuleState: Dispatch<SetStateAction<ModuleState<S>>> = () => {}
-  const context = createContext<Context<S>>({ moduleState: initModuleState, setModuleState })
+  const moduleState: ModuleState<S> = { name: module.name, nodes: {}, defaultState }
+  const refModuleState: RefObject<ModuleState<S>> = { current: moduleState }
+  const setRefModuleState: Dispatch<SetStateAction<RefObject<ModuleState<S>>>> = () => {}
+  const context = createContext<Context<S>>({
+    refModuleState,
+    setRefModuleState,
+  })
 
-  THUNK_CONTEXT_MAP.theMap[name] = { context, initModuleState }
+  THUNK_CONTEXT_MAP.theMap[name] = { context, moduleState }
   const theList = Object.keys(THUNK_CONTEXT_MAP.theMap)
   THUNK_CONTEXT_MAP.theList = theList
 

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -1,9 +1,9 @@
 import type { ThunkModule, toDoModule } from '../thunkModule'
 import type { UseThunkModuleState } from '../useThunk'
 import { deepCopy, genID } from '../utils'
-import type { ModuleState, NodeState, NodeStateMap, State } from './types'
+import type { ModuleState, NodeState, NodeStateMap, RefModuleState, State } from './types'
 
-export type { ModuleState, NodeState, NodeStateMap, State }
+export type { ModuleState, NodeState, NodeStateMap, RefModuleState, State }
 
 /**
  * get defaultID
@@ -16,8 +16,6 @@ export const getDefaultID = <S extends State>(moduleState: ModuleState<S>) => {
 }
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
  * ensuring defaultID.
  *
  * @param id id. use ensured defaultID if id is not provided.
@@ -82,10 +80,6 @@ export const getStateOrNullByModule = <S extends State>(
 }
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
- * XXX (moduleState): set state as defaultState if state does not exist.
- *
  * get state from moduleState.
  *
  * @param moduleState moduleState.
@@ -112,10 +106,6 @@ export const getStateByModule = <S extends State>(
 }
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
- * XXX (moduleState): set state as defaultState if state does not exist.
- *
  * get state from useThunkModuleState ([moduleState, doModule]).
  *
  * @param theUseThunkModuleState useThunkModuleState
@@ -127,6 +117,7 @@ export const getState = <S extends State, T extends ThunkModule<S>>(
   id?: string | null,
 ): [Readonly<S>, toDoModule<S, T>, string] => {
   const [moduleState, doModule] = theUseThunkModuleState
+
   const theID = ensureDefaultID(id, moduleState)
   const state = getStateByModule(moduleState, theID)
   return [state, doModule, theID]

--- a/src/states/types.ts
+++ b/src/states/types.ts
@@ -1,3 +1,5 @@
+import type { RefObject } from 'react'
+
 /**
  * the most fundamental state.
  *
@@ -13,7 +15,9 @@ export type NodeState<S extends State> = {
   state: S
 }
 
-// ModuleState
+/**
+ * module state
+ */
 export type ModuleState<S extends State> = {
   name: string
   nodes: NodeStateMap<S>
@@ -24,3 +28,5 @@ export type ModuleState<S extends State> = {
 export type NodeStateMap<S extends State> = {
   [key: string]: NodeState<S>
 }
+
+export type RefModuleState<S extends State> = RefObject<ModuleState<S>>

--- a/src/thunk/get.ts
+++ b/src/thunk/get.ts
@@ -1,10 +1,6 @@
 import type { State } from '../states'
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
- * XXX (moduleState): set state as defaultState if state does not exist.
- *
  * get the state of the id. use defaultID if id is not specified.
  */
 export type get<S extends State> = (id?: string | null) => S

--- a/src/thunk/set.ts
+++ b/src/thunk/set.ts
@@ -3,8 +3,6 @@ import type { ActionOrThunk } from '../action/ActionOrThunk'
 import type { State } from '../states'
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
  * * set(id, data): upsert data to moduleState.
  * * set(thunk): evaluate thunk<S>.
  */

--- a/src/thunkContext/ThunkContext.tsx
+++ b/src/thunkContext/ThunkContext.tsx
@@ -9,7 +9,7 @@ type Props = {
 /**
  * ThunkContext
  *
- * Thunk Context. Always wraps `<App />` in `main.tsx`.
+ * Thunk Context. Always wraps `App in `main.tsx`.
  *
  * @param props
  * @returns
@@ -26,20 +26,20 @@ const ThunkContext = (props: Props): JSX.Element => {
   const theModule = modules[0]
 
   // 1. get the context and moduleState from context map.
-  const { context: Context_m, initModuleState } = THUNK_CONTEXT_MAP.theMap[theModule]
+  const { context: Context_m, moduleState } = THUNK_CONTEXT_MAP.theMap[theModule]
 
   // 2. setup moduleState.
   // biome-ignore lint/correctness/useHookAtTopLevel: the order is fixed.
-  const [moduleState, setModuleState] = useState(initModuleState)
+  const [refModuleState, setRefModuleState] = useState(() => ({ current: moduleState }))
 
   // 3. value reset only if moduleState is changed.
   // biome-ignore lint/correctness/useHookAtTopLevel: the order is fixed.
   const value = useMemo(
     () => ({
-      moduleState,
-      setModuleState,
+      refModuleState,
+      setRefModuleState,
     }),
-    [moduleState],
+    [refModuleState],
   )
 
   // 4. get theChildren

--- a/src/thunkContext/index.ts
+++ b/src/thunkContext/index.ts
@@ -2,8 +2,8 @@ import type { Context } from './types'
 export type { Context }
 
 // THUNK_CONTEXT_MAP is used in registerThunk and useThunkReducer
-import { THUNK_CONTEXT_MAP, type ThunkContextMap } from './thunkContextMap'
-export { THUNK_CONTEXT_MAP, type ThunkContextMap }
+import { getMod, THUNK_CONTEXT_MAP, type ThunkContextMap } from './thunkContextMap'
+export { getMod, THUNK_CONTEXT_MAP, type ThunkContextMap }
 
 import ThunkContext from './ThunkContext'
 export { ThunkContext }

--- a/src/thunkContext/thunkContextMap.ts
+++ b/src/thunkContext/thunkContextMap.ts
@@ -1,5 +1,5 @@
 import type { Context as rContext } from 'react'
-import type { ModuleState } from '../states'
+import type { ModuleState, State } from '../states'
 import type { Context } from './types'
 
 export type ThunkContextMap = {
@@ -8,7 +8,7 @@ export type ThunkContextMap = {
       // biome-ignore lint/suspicious/noExplicitAny: module can be any type
       context: rContext<Context<any>>
       // biome-ignore lint/suspicious/noExplicitAny: module can be any type
-      initModuleState: ModuleState<any>
+      moduleState: ModuleState<any>
     }
   }
   theList: string[]
@@ -24,4 +24,14 @@ export const THUNK_CONTEXT_MAP: ThunkContextMap = {
 /////
 export const resetThunkContetMap = () => {
   Object.assign(THUNK_CONTEXT_MAP, { theMap: {}, theList: [] })
+}
+
+/**
+ * get the module state by module name.
+ *
+ * @param moduleName module name.
+ * @returns module state.
+ */
+export const getMod = <S extends State>(moduleName: string): Readonly<ModuleState<S>> => {
+  return THUNK_CONTEXT_MAP.theMap[moduleName].moduleState
 }

--- a/src/thunkContext/types.ts
+++ b/src/thunkContext/types.ts
@@ -1,7 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react'
-import type { ModuleState, State } from '../states'
+import type { State } from '../states'
+import type { RefModuleState } from '../states/types'
 
 export type Context<S extends State> = {
-  moduleState: ModuleState<S>
-  setModuleState: Dispatch<SetStateAction<ModuleState<S>>>
+  refModuleState: RefModuleState<S>
+  setRefModuleState: Dispatch<SetStateAction<RefModuleState<S>>>
 }

--- a/src/thunkModule/doModule.ts
+++ b/src/thunkModule/doModule.ts
@@ -63,11 +63,9 @@ export const constructDoModule = <S extends State, T extends ThunkModule<S>>(mod
 }
 
 /**
- * doMod
- *
  * get the doModule by module name.
  *
- * @param moduleName the module name.
+ * @param moduleName module name.
  * @returns doModule
  */
 export const doMod = <S extends State, T extends ThunkModule<S>>(moduleName: string) => {

--- a/src/useThunk/index.ts
+++ b/src/useThunk/index.ts
@@ -1,5 +1,8 @@
 import useThunkModuleState, { type UseThunkModuleState } from './useThunkModuleState'
 export { useThunkModuleState, type UseThunkModuleState }
 
+import useThunkRefModuleState, { type UseThunkRefModuleState } from './useThunkRefModuleState'
+export { useThunkRefModuleState, type UseThunkRefModuleState }
+
 import useThunk, { type UseThunk } from './useThunk'
 export { useThunk, type UseThunk }

--- a/src/useThunk/useThunk.ts
+++ b/src/useThunk/useThunk.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { getState, type State } from '../states'
 import type { ThunkModule, toDoModule } from '../thunkModule'
-import useThunkModuleState from './useThunkModuleState'
+import useThunkRefModuleState from './useThunkRefModuleState'
 
 /**
  * type of useThunk.
@@ -11,10 +11,6 @@ import useThunkModuleState from './useThunkModuleState'
 export type UseThunk<S extends State, T extends ThunkModule<S>> = [Readonly<S>, toDoModule<S, T>, string]
 
 /**
- * XXX (moduleState) set theID to defaultID if defaultID does not exist.
- *
- * XXX (moduleState): set state as defaultState if state does not exist.
- *
  * get state of the id, doModule, and id.
  *
  * use defaultID is id is not provided.
@@ -24,11 +20,11 @@ export type UseThunk<S extends State, T extends ThunkModule<S>> = [Readonly<S>, 
  * @returns [state, doModule, id]
  */
 const useThunk = <S extends State, T extends ThunkModule<S>>(module: T, id?: string) => {
-  const useModuleModule = useThunkModuleState<S, T>(module)
+  const [refModuleState, doModule] = useThunkRefModuleState<S, T>(module)
 
   const ret: UseThunk<S, T> = useMemo(() => {
-    return getState(useModuleModule, id)
-  }, [useModuleModule, id])
+    return getState([refModuleState.current, doModule], id)
+  }, [refModuleState, id])
 
   return ret
 }

--- a/src/useThunk/useThunkModuleState.ts
+++ b/src/useThunk/useThunkModuleState.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import type { ModuleState, State } from '../states'
-import { constructDoModule, DO_MODULE_MAP, type ThunkModule, type toDoModule } from '../thunkModule'
-import useThunkReducer from './useThunkReducer'
+import type { ThunkModule, toDoModule } from '../thunkModule'
+import useThunkRefModuleState from './useThunkRefModuleState'
 
 /**
  * type of useThunkModuleState.
@@ -17,22 +17,14 @@ export type UseThunkModuleState<S extends State, T extends ThunkModule<S>> = [
  * get moduleState and doModule.
  *
  * @param module
- * @returns [moduleState, doModule]
+ * @returns [refModuleState, doModule]
  */
 const useThunkModuleState = <S extends State, T extends ThunkModule<S>>(module: T) => {
-  const { name } = module
-
-  // 2. useThunkReducer
-  const [moduleState, set] = useThunkReducer<S>(name)
-
-  if (!DO_MODULE_MAP[name]) {
-    constructDoModule(module, set)
-  }
-  const doModule = DO_MODULE_MAP[name] as toDoModule<S, T>
+  const [refModuleState, doModule] = useThunkRefModuleState<S, T>(module)
 
   const ret: UseThunkModuleState<S, T> = useMemo(() => {
-    return [moduleState, doModule]
-  }, [moduleState, doModule])
+    return [refModuleState.current, doModule]
+  }, [refModuleState])
 
   return ret
 }

--- a/src/useThunk/useThunkReducer.ts
+++ b/src/useThunk/useThunkReducer.ts
@@ -1,10 +1,10 @@
 //https://medium.com/solute-labs/configuring-thunk-action-creators-and-redux-dev-tools-with-reacts-usereducer-hook-5a1608476812
 //https://github.com/nathanbuchar/react-hook-thunk-reducer/blob/master/src/thunk-reducer.js
 
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext } from 'react'
 import { upsert } from '../defaultThunkFuncs'
 import { defaultReducer } from '../reducer'
-import { getStateByModule, getStateOrNullByModule, type ModuleState, type State } from '../states'
+import { getStateByModule, getStateOrNullByModule, type RefModuleState, type State } from '../states'
 import type { dispatch, get, getModuleState, getOrNull, set } from '../thunk'
 import { THUNK_CONTEXT_MAP } from '../thunkContext'
 
@@ -14,30 +14,15 @@ import { THUNK_CONTEXT_MAP } from '../thunkContext'
  * Augments React's useReducer() hook so that the action
  * setter (dispatcher) supports thunks.
  */
-export default <S extends State>(moduleName: string): [ModuleState<S>, set<S>] => {
+export default <S extends State>(moduleName: string): [RefModuleState<S>, set<S>] => {
   const { context } = THUNK_CONTEXT_MAP.theMap[moduleName]
 
-  // moduleState_c as the snapshot of the moduleState from the context.
-  const { moduleState: moduleState_c, setModuleState: setModuleState_c } = useContext(context)
-
-  // refModuleState is used only internally to sync the moduleState after dispatch.
-  const refModuleState: { current: ModuleState<S> } = useMemo(
-    () => ({ current: moduleState_c }),
-    [moduleState_c],
-  )
+  const { refModuleState, setRefModuleState } = useContext(context)
 
   // always use getModuleState to get the current moduleState.
   const getModuleState: getModuleState<S> = useCallback(() => {
     return refModuleState.current
-  }, [refModuleState])
-
-  const setModuleState = useCallback(
-    (newModuleState: ModuleState<S>) => {
-      refModuleState.current = newModuleState
-      setModuleState_c(newModuleState)
-    },
-    [refModuleState],
-  )
+  }, [refModuleState.current])
 
   const getOrNull: getOrNull<S> = useCallback(
     (id?: string | null) => {
@@ -63,12 +48,14 @@ export default <S extends State>(moduleName: string): [ModuleState<S>, set<S>] =
         return
       }
 
-      // action is not function. so action is BaseAction
-      const newModuleState = defaultReducer(getModuleState(), action)
+      const moduleState = getModuleState()
 
-      setModuleState(newModuleState)
+      // action is not function. so action is BaseAction
+      const newModuleState = defaultReducer(moduleState, action)
+
+      setRefModuleState({ current: newModuleState })
     },
-    [getModuleState, setModuleState],
+    [getModuleState],
   )
 
   const set: set<S> = useCallback(
@@ -91,5 +78,5 @@ export default <S extends State>(moduleName: string): [ModuleState<S>, set<S>] =
     [dispatch],
   )
 
-  return [moduleState_c, set] // moduleState_c as the snapshot from the context.
+  return [refModuleState, set]
 }

--- a/src/useThunk/useThunkRefModuleState.ts
+++ b/src/useThunk/useThunkRefModuleState.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import type { RefModuleState, State } from '../states'
+import { constructDoModule, DO_MODULE_MAP, type ThunkModule, type toDoModule } from '../thunkModule'
+import useThunkReducer from './useThunkReducer'
+
+/**
+ * type of useThunkRefModuleState.
+ *
+ * [moduleState, doModule]
+ */
+export type UseThunkRefModuleState<S extends State, T extends ThunkModule<S>> = [
+  Readonly<RefModuleState<S>>,
+  toDoModule<S, T>,
+]
+
+/**
+ * get refModuleState and doModule.
+ *
+ * @param module
+ * @returns [refModuleState, doModule]
+ */
+const useThunkRefModuleState = <S extends State, T extends ThunkModule<S>>(module: T) => {
+  const { name } = module
+
+  // 2. useThunkReducer
+  const [refModuleState, set] = useThunkReducer<S>(name)
+
+  if (!DO_MODULE_MAP[name]) {
+    constructDoModule(module, set)
+  }
+  const doModule = DO_MODULE_MAP[name] as toDoModule<S, T>
+
+  const ret: UseThunkRefModuleState<S, T> = useMemo(() => {
+    return [refModuleState, doModule]
+  }, [refModuleState])
+
+  return ret
+}
+
+export default useThunkRefModuleState

--- a/tests/Child.tsx
+++ b/tests/Child.tsx
@@ -10,7 +10,8 @@ export default (props: Props) => {
 
   const useChild = useThunkModuleState<ModChild.State, typeof ModChild>(ModChild)
   const [moduleChild, doChild] = useChild
-  const child = getStateOrNullByModule(moduleChild, myID) || moduleChild.defaultState
+  // use -100 to check that the child does not exist in moduleChild.
+  const child = getStateOrNullByModule(moduleChild, myID) || { count: -100 }
 
   const { count } = child
 

--- a/tests/async-app.test.tsx
+++ b/tests/async-app.test.tsx
@@ -1,0 +1,101 @@
+import { act, useEffect } from 'react'
+import ReactDOM from 'react-dom/client'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+import { registerThunk, ThunkContext, useThunk } from '../src/index'
+import { getMod, resetThunkContetMap } from '../src/thunkContext/thunkContextMap'
+import { resetID } from '../src/utils/genID'
+import * as ModChild2 from './child2'
+import { sleep } from './utils'
+
+let container: HTMLDivElement | null
+let root: ReactDOM.Root | null
+
+beforeEach(() => {
+  resetThunkContetMap()
+  resetID()
+
+  registerThunk(ModChild2)
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  root = ReactDOM.createRoot(container)
+
+  // @ts-expect-error set IS_REACT_ACT_ENVIRONMENT
+  global.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterEach(() => {
+  root = null
+  if (container === null) {
+    return
+  }
+
+  document.body.removeChild(container)
+  container = null
+})
+
+it('async-app', async () => {
+  const App = () => {
+    const [child2, doChild2] = useThunk<ModChild2.State, typeof ModChild2>(ModChild2)
+
+    // init
+    useEffect(() => {
+      doChild2.asyncIncrement1(7, 80)
+      doChild2.asyncIncrement2(6, 100)
+    }, [])
+
+    return (
+      <>
+        <p className='count1'>{child2.count1}</p>
+        <p className='count2'>{child2.count2}</p>
+        <p className='count'>{child2.count}</p>
+      </>
+    )
+  }
+
+  const App2 = () => {
+    return (
+      <ThunkContext>
+        <App />
+        <App />
+      </ThunkContext>
+    )
+  }
+
+  // do act
+
+  act(() => {
+    console.info('start: time:', new Date().getMilliseconds())
+    root?.render(<App2 />)
+  })
+
+  if (container === null) {
+    return
+  }
+
+  await sleep(650)
+
+  const count1s = container.querySelectorAll('.count1')
+  const count2s = container.querySelectorAll('.count2')
+  const counts = container.querySelectorAll('.count')
+
+  const count1 = count1s[0]
+  const count2 = count2s[0]
+  const count = counts[0]
+
+  expect(count1.textContent).toBe('14')
+  expect(count2.textContent).toBe('12')
+  expect(count.textContent).toBe('26')
+
+  const child2Module = getMod(ModChild2.name)
+  console.info('child2Module:', child2Module)
+  const child2ModuleNodeKeys = Object.keys(child2Module.nodes)
+  expect(child2ModuleNodeKeys.length).toBe(1)
+  const child2ID = child2ModuleNodeKeys[0]
+  expect(child2ID).toBe(child2Module.defaultID)
+  const { count: count_s, count1: count1_s, count2: count2_s } = child2Module.nodes[child2ID].state
+  expect(count1_s).toBe(14)
+  expect(count2_s).toBe(12)
+  expect(count_s).toBe(26)
+})

--- a/tests/child.ts
+++ b/tests/child.ts
@@ -1,6 +1,6 @@
 import { init as _init, type State as _State, type Thunk, update } from '../src'
 
-export const name = 'test/theChild'
+export const name = 'test/child'
 
 export interface State extends _State {
   count: number

--- a/tests/child2.ts
+++ b/tests/child2.ts
@@ -1,0 +1,60 @@
+import type { State as _State, Thunk } from '../src'
+import { arrayN, sleep } from './utils'
+
+export const name = 'test/child2'
+
+export interface State extends _State {
+  count1: number
+  count2: number
+  count: number
+}
+
+export const defaultState: State = {
+  count1: 0,
+  count2: 0,
+  count: 0,
+}
+
+export const increment1 = (): Thunk<State> => {
+  return (set, get) => {
+    const me = get()
+    const { count, count1 } = me
+
+    console.info('increment1: count:', count, 'count1:', count1, 'time:', new Date().getMilliseconds())
+
+    set(undefined, { count: count + 1, count1: count1 + 1 })
+  }
+}
+
+export const increment2 = (): Thunk<State> => {
+  return (set, get) => {
+    const me = get()
+    const { count, count2 } = me
+
+    console.info('increment2: count:', count, 'count2:', count2, 'time:', new Date().getMilliseconds())
+
+    set(undefined, { count: count + 1, count2: count2 + 1 })
+  }
+}
+
+export const asyncIncrement1 = (n: number, sleepMS: number): Thunk<State> => {
+  return async (set) => {
+    for (const idx in arrayN(n)) {
+      set(increment1())
+      console.info(`asyncIncrement1 (${idx}): to sleep: time:`, new Date().getMilliseconds())
+      await sleep(sleepMS)
+      console.info(`asyncIncrement1: (${idx}): after sleep: time:`, new Date().getMilliseconds())
+    }
+  }
+}
+
+export const asyncIncrement2 = (n: number, sleepMS: number): Thunk<State> => {
+  return async (set) => {
+    for (const idx in arrayN(n)) {
+      set(increment2())
+      console.info(`asyncIncrement2 (${idx}): to sleep: time:`, new Date().getMilliseconds())
+      await sleep(sleepMS)
+      console.info(`asyncIncrement2 (${idx}): after sleep: time:`, new Date().getMilliseconds())
+    }
+  }
+}

--- a/tests/many-apps2.test.tsx
+++ b/tests/many-apps2.test.tsx
@@ -2,7 +2,7 @@ import { act, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { genID, registerThunk, ThunkContext, useThunk } from '../src/index'
-import { resetThunkContetMap } from '../src/thunkContext/thunkContextMap'
+import { getMod, resetThunkContetMap } from '../src/thunkContext/thunkContextMap'
 import { resetID } from '../src/utils/genID'
 import * as ModChild from './child'
 import Parent from './Parent'
@@ -127,6 +127,8 @@ it('many-apps-2 (useThunk)', async () => {
   const childButtons2 = container.querySelectorAll('.child-button-2')
   const childButtons3 = container.querySelectorAll('.child-button-3')
 
+  const childModule = getMod<ModChild.State>(ModChild.name)
+
   expect(parentMyIDs.length).toBe(4)
   expect(parentDefaultIDs.length).toBe(4)
   expect(parentCounts.length).toBe(4)
@@ -213,15 +215,35 @@ it('many-apps-2 (useThunk)', async () => {
   expect(childID0).not.toBe(childID3)
   expect(childID7).toBe(childDefaultID)
   expect(childCounts[0].textContent).toBe(`${childID0}: 1`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
-  expect(childCounts[3].textContent).toBe(`${childID3}: 0`) // childID3 has been removed by App2.
+  expect(childCounts[3].textContent).toBe(`${childID3}: -100`) // childID3 has been removed by App2.
   expect(childCounts[4].textContent).toBe(`${childID4}: 1`)
-  expect(childCounts[5].textContent).toBe(`${childID5}: 0`)
+  expect(childCounts[5].textContent).toBe(`${childID5}: -100`)
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
-  console.info('many-apps: to click parent-0 button (1st)')
+  console.info(
+    'many-apps2: childModule.nodes:',
+    childModule.nodes,
+    'childID0:',
+    childID0,
+    'childID1:',
+    childID1,
+    'childID3:',
+    childID3,
+  )
+
+  expect(childModule.nodes[childID0].state.count).toBe(1)
+  expect(childModule.nodes[childID1]).toBeUndefined()
+  expect(childModule.nodes[childID2].state.count).toBe(6)
+  expect(childModule.nodes[childID3]).toBeUndefined()
+  expect(childModule.nodes[childID4].state.count).toBe(1)
+  expect(childModule.nodes[childID5]).toBeUndefined()
+  expect(childModule.nodes[childID6].state.count).toBe(6)
+  expect(childModule.nodes[childID7].state.count).toBe(10)
+
+  console.info('many-apps2: to click parent-0 button (1st)')
 
   act(() => parentButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
   expect(consoleSpy).not.toHaveBeenCalled()
@@ -235,11 +257,11 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${parentID2}: 1`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 1`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 1`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
-  expect(childCounts[3].textContent).toBe(`${childID3}: 0`)
+  expect(childCounts[3].textContent).toBe(`${childID3}: -100`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 1`)
-  expect(childCounts[5].textContent).toBe(`${childID5}: 0`)
+  expect(childCounts[5].textContent).toBe(`${childID5}: -100`)
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
@@ -259,11 +281,11 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${parentID2}: 1`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 1`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
-  expect(childCounts[3].textContent).toBe(`${childID3}: 0`)
+  expect(childCounts[3].textContent).toBe(`${childID3}: -100`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 1`)
-  expect(childCounts[5].textContent).toBe(`${childID5}: 0`)
+  expect(childCounts[5].textContent).toBe(`${childID5}: -100`)
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
@@ -285,11 +307,11 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${parentID2}: 1`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 1`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
   expect(childCounts[3].textContent).toBe(`${childID3}: 3`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 1`)
-  expect(childCounts[5].textContent).toBe(`${childID5}: 0`)
+  expect(childCounts[5].textContent).toBe(`${childID5}: -100`)
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
@@ -309,11 +331,11 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${parentID2}: 1`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 1`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
   expect(childCounts[3].textContent).toBe(`${childID3}: 3`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 7`)
-  expect(childCounts[5].textContent).toBe(`${childID5}: 0`)
+  expect(childCounts[5].textContent).toBe(`${childID5}: -100`)
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
@@ -333,7 +355,7 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${parentID2}: 1`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 1`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
   expect(childCounts[3].textContent).toBe(`${childID3}: 3`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 7`)
@@ -341,7 +363,7 @@ it('many-apps-2 (useThunk)', async () => {
   expect(childCounts[6].textContent).toBe(`${childID6}: 6`)
   expect(childCounts[7].textContent).toBe(`${childID7}: 10`)
 
-  console.info('many-apps: to remove parent-0')
+  console.info('many-apps2: to remove parent-0')
   act(() => parentRemoves[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
   const newParentMyIDs = container.querySelectorAll('.parent-my-id')
@@ -366,7 +388,7 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${newParentID2}: 0`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 0`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
   expect(childCounts[3].textContent).toBe(`${childID3}: 3`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 7`)
@@ -383,7 +405,7 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultNodeIDs[2].textContent).toBe(`${newParentID2}: ${newParentID0}`)
   expect(parentDefaultNodeIDs[3].textContent).toBe(`${parentID3}: ${newParentID0}`)
 
-  console.info('many-apps: to remove parent-0 (again)')
+  console.info('many-apps2: to remove parent-0 (again)')
   act(() => parentRemoves[0].dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
   const newParentMyID2s = container.querySelectorAll('.parent-my-id')
@@ -410,7 +432,7 @@ it('many-apps-2 (useThunk)', async () => {
   expect(parentDefaultCounts[2].textContent).toBe(`${newParentID22}: 0`)
   expect(parentDefaultCounts[3].textContent).toBe(`${parentID3}: 0`)
   expect(childCounts[0].textContent).toBe(`${childID0}: 3`)
-  expect(childCounts[1].textContent).toBe(`${childID1}: 0`)
+  expect(childCounts[1].textContent).toBe(`${childID1}: -100`)
   expect(childCounts[2].textContent).toBe(`${childID2}: 6`)
   expect(childCounts[3].textContent).toBe(`${childID3}: 3`)
   expect(childCounts[4].textContent).toBe(`${childID4}: 7`)

--- a/tests/parent.ts
+++ b/tests/parent.ts
@@ -1,6 +1,6 @@
 import type { State as _State, Thunk } from '../src'
 
-export const name = 'test/theParent'
+export const name = 'test/parent'
 
 export interface State extends _State {
   count: number

--- a/tests/reducer/default-reducer.test.ts
+++ b/tests/reducer/default-reducer.test.ts
@@ -4,9 +4,9 @@ import type { BaseAction } from '../../src/action'
 import { defaultReducer } from '../../src/reducer'
 import * as ModChild from '../child'
 
-it('create reducer', () => {
+it('default-reducer: non-exist action', () => {
   const action: BaseAction = {
-    myID: '1',
+    id: '1',
     type: 'non-exist',
   }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,3 @@
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const arrayN = (n: number) => Array.from({ length: n }, (_, index) => index)


### PR DESCRIPTION
1. have refModuleState in ThunkContext.
2. THUNK_CONTEXT_MAP includes moduleState.
3. no newNodes and no newModuleState in reducers.
4. useThunk / useThunkModuleState / useThunkRefModuleState.
5. implement getMod.
6. pass async-app test.